### PR TITLE
Fix transformation of non-ASCII on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ Suggests:
     pillar,
     readr,
     rlang,
-    testthat
+    testthat,
+    withr
 License: GPL-3
 Encoding: UTF-8
 LazyData: true

--- a/R/io.R
+++ b/R/io.R
@@ -110,7 +110,7 @@ transform_lines_enc_one <- function(path, fun, file_encoding = "UTF-8", ok = TRU
   sep <- detect_sep(path)
   tryCatch(
     {
-      new_text <- as.character(fun(text))
+      new_text <- to_utf8(fun(text))
       if (!isTRUE(identical(unclass(text), unclass(new_text)))) {
         if (write_back) {
           write_lines_enc(new_text, path, file_encoding = file_encoding, sep = sep)

--- a/tests/testthat/test-transform-lines.R
+++ b/tests/testthat/test-transform-lines.R
@@ -88,6 +88,20 @@ test_that("forward-reverse transformation works for CRLF", {
   expect_true(all(ret))
 })
 
+test_that("forward-reverse transformation works for latin1", {
+  paths <- setup_paths(file_encoding = "latin1", text = all_texts[3])
+  digest_before <- vapply(paths, function(x) digest::digest(file = x), character(1L))
+  ret <- transform_lines_enc(paths, add_one)
+  expect_message(
+    ret <- transform_lines_enc(paths, remove_one, verbose = TRUE),
+    paste0("Files changed: ", paths[ret][[1]]),
+    fixed = TRUE
+  )
+  digest_after <- vapply(paths, function(x) digest::digest(file = x), character(1L))
+  expect_equal(digest_before, digest_after)
+  expect_true(all(ret))
+})
+
 test_that("remove transformation works for latin1", {
   paths <- setup_paths(file_encoding = "latin1", text = all_texts[-4])
   digest_before <- vapply(paths, function(x) digest::digest(file = x), character(1L))

--- a/tests/testthat/test-transform-lines.R
+++ b/tests/testthat/test-transform-lines.R
@@ -14,7 +14,9 @@ all_texts_length_two <- list(
 )
 
 add_one <- function(x) c(x, "")
+add_one_native <- function(x) to_native(add_one(x))
 remove_one <- function(x) x[-length(x)]
+remove_one_native <- function(x) to_native(remove_one(x))
 error_if_long <- function(x) {
   len_x <- length(x)
   if (len_x > 2) {
@@ -89,11 +91,11 @@ test_that("forward-reverse transformation works for CRLF", {
 })
 
 test_that("forward-reverse transformation works for latin1", {
-  paths <- setup_paths(file_encoding = "latin1", text = all_texts[3])
+  paths <- setup_paths(text = all_texts[3])
   digest_before <- vapply(paths, function(x) digest::digest(file = x), character(1L))
-  ret <- transform_lines_enc(paths, add_one)
+  ret <- transform_lines_enc(paths, add_one_native)
   expect_message(
-    ret <- transform_lines_enc(paths, remove_one, verbose = TRUE),
+    ret <- transform_lines_enc(paths, remove_one_native, verbose = TRUE),
     paste0("Files changed: ", paths[ret][[1]]),
     fixed = TRUE
   )

--- a/tests/testthat/test-transform-lines.R
+++ b/tests/testthat/test-transform-lines.R
@@ -91,11 +91,10 @@ test_that("forward-reverse transformation works for CRLF", {
 })
 
 test_that("forward-reverse transformation works for latin1", {
-  # c.f. rlang::mut_latin1_locale()
-  locale <- if (.Platform$OS.type == "windows") "English_United States.1252" else "en_US.ISO8859-1"
+  skip_if(.Platform$OS.type != "windows")
 
   withr::with_locale(
-    c(LC_CTYPE = locale),
+    c(LC_CTYPE = "English_United States.1252"),
     {
       paths <- setup_paths(text = all_texts[3])
       digest_before <- vapply(paths, function(x) digest::digest(file = x), character(1L))


### PR DESCRIPTION
I believe this fixes https://github.com/r-lib/styler/issues/329.

As described the original issue above, in `transform_lines_enc_one()`, there is nothing to ensure `new_text` is in the UTF-8 encoding while `write_lines_enc()` requires UTF-8.

https://github.com/krlmlr/enc/blob/883df89f77bb5f8646b9a8fa94cc72120cdf0c81/R/io.R#L109-L116

I don't see any major drawbacks to change `as.character()` to `to_utf8()`, but I'm still not sure why `as.character()` was introduced here. Shouldn't it throw an error when `fun()` returns non-characters? What cases does it consider about?