### PR TITLE
Fixes `NOTE` in CRAN checks about `LazyData`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ Suggests:
     withr
 License: GPL-3
 Encoding: UTF-8
-LazyData: true
 BugReports: https://github.com/krlmlr/enc/issues
 URL: https://github.com/krlmlr/enc
 RoxygenNote: 7.2.3


### PR DESCRIPTION
cf. https://cran.rstudio.com/web/checks/check_results_enc.html

Since there is no `data/`, this `DESCRIPTION` field should be unnecessary.